### PR TITLE
Suffix reserved names with underscore.

### DIFF
--- a/piqic-ocaml/piqic_common.ml
+++ b/piqic-ocaml/piqic_common.ml
@@ -406,8 +406,22 @@ let flag_cc = ref false
 let flag_gen_preserve_unknown_fields = ref false
 
 
+let ocaml_reserved = Hashtbl.create 83
+let () = Array.iter (fun n -> Hashtbl.add ocaml_reserved n ())
+  [|"and";        "as";       "assert"; "asr";     "begin";   "class";
+    "constraint"; "do";       "done";   "downto";  "else";    "end";
+    "exception";  "external"; "false";  "for";     "fun";     "function";
+    "functor";    "if";       "in";     "include"; "inherit"; "initializer";
+    "land";       "lazy";     "let";    "lor";     "lsl";     "lsr";
+    "lxor";       "match";    "method"; "mod";     "module";  "mutable";
+    "new";        "object";   "of";     "open";    "or";      "private";
+    "rec";        "sig";      "struct"; "then";    "to";      "true";
+    "try";        "type";     "val";    "virtual"; "when";    "while";
+    "with"|]
+
 (* ocaml name of piqi name *)
 let ocaml_name n =
+  if Hashtbl.mem ocaml_reserved n then n ^ "_" else
   let n =
     if !flag_normalize_names
     then U.normalize_name n

--- a/piqic-ocaml/piqic_ocaml.ml
+++ b/piqic-ocaml/piqic_ocaml.ml
@@ -42,6 +42,10 @@ let arg__normalize_names =
   "--normalize-names", Arg.Bool (fun x -> C.flag_normalize_names := x),
     "true|false turn CamlCase-style names into \"camel_case\" (default = true)"
 
+let arg__reserved_name =
+  "--reserved-name", Arg.String (fun x -> Hashtbl.add Piqic_common.ocaml_reserved x ()),
+    "add a reserved name in addition to the standard OCaml keywords"
+
 let arg__gen_defaults =
   "--gen-defaults", Arg.Set flag_gen_defaults,
     "(depreacted) always enabled: generate default value constructors for generated types"
@@ -201,6 +205,7 @@ let speclist = Piqi_compile.getopt_speclist @
   [
     Piqi_command.arg_C;
     arg__normalize_names;
+    arg__reserved_name;
     arg__pp;
     arg__gen_defaults;
     arg__gen_preserve_unknown_fields;


### PR DESCRIPTION
I was running piqi-ocaml on a bunch of external proto files and found it was a bit of a hazzle to deal with reserved names, most notoriously "type".  Can you accept this patch which adds an understore to all the standard keywords?  It also adds an option --reserved-name to add additional keywords, e.g. when using a syntax extension.
