### PR TITLE
Fix typo'd "DEPRECATED"

### DIFF
--- a/piqic-ocaml/piqic_ocaml.ml
+++ b/piqic-ocaml/piqic_ocaml.ml
@@ -48,7 +48,7 @@ let arg__reserved_name =
 
 let arg__gen_defaults =
   "--gen-defaults", Arg.Set flag_gen_defaults,
-    "(depreacted) always enabled: generate default value constructors for generated types"
+    "(DEPRECATED) always enabled: generate default value constructors for generated types"
 
 let arg__gen_preserve_unknown_fields =
   "--gen-preserve-unknown-fields", Arg.Set C.flag_gen_preserve_unknown_fields,


### PR DESCRIPTION
Change (depreacted) to (DEPRECATED) for uniformity and spelling
