### PR TITLE
Ensure the removal of many non-tail recursive calls

### DIFF
--- a/examples/addressbook/Makefile
+++ b/examples/addressbook/Makefile
@@ -1,6 +1,7 @@
 .PHONY: all ocaml test ocaml_ext test_ext clean
 
 
+PACKS=+core core_kernel
 all: ocaml test ocaml_ext test_ext
 
 

--- a/examples/addressbook/Makefile.ocaml
+++ b/examples/addressbook/Makefile.ocaml
@@ -16,7 +16,8 @@ endif
 PRE_TARGETS = addressbook_piqi.ml
 
 export OCAMLPATH := ../..:$(OCAMLPATH)
-PACKS = piqirun.pb
+PACKS = core core_kernel piqirun.pb
+export THREADS=yes
 
 
 PIQIC = ../../piqic-ocaml/piqic-ocaml

--- a/examples/addressbook/Makefile.ocaml_ext
+++ b/examples/addressbook/Makefile.ocaml_ext
@@ -10,7 +10,8 @@ SOURCES = \
 
 
 export OCAMLPATH := ../..:$(OCAMLPATH)
-PACKS = piqirun.ext
+PACKS = core core_kernel piqirun.ext
+export THREADS=yes
 
 
 PIQI_FILES = addressbook.proto.piqi

--- a/examples/custom-types/Makefile
+++ b/examples/custom-types/Makefile
@@ -11,7 +11,8 @@ SOURCES = \
 
 
 export OCAMLPATH := ../..:$(OCAMLPATH)
-PACKS = piqirun.pb num
+PACKS = core core_kernel piqirun.pb num
+export THREADS=yes
 
 
 PIQI_FILES = example.piqi skvl.piqi

--- a/examples/piq-config/Makefile
+++ b/examples/piq-config/Makefile
@@ -10,8 +10,8 @@ SOURCES = \
 
 
 export OCAMLPATH := ../..:$(OCAMLPATH)
-PACKS = piqirun.ext
-
+PACKS = core core_kernel piqirun.ext
+export THREADS=yes
 
 PIQI_FILES = config.piqi
 PIQI_ML_FILES = config_piqi.ml config_piqi_ext.ml

--- a/piqic-ocaml/Makefile
+++ b/piqic-ocaml/Makefile
@@ -1,6 +1,7 @@
 OCAMLMAKEFILE := ../make/OCamlMakefile
 
-
+export ANNOTATE=yes
+export THREADS=yes
 RESULT = piqic-ocaml
 
 
@@ -18,7 +19,8 @@ SOURCES = \
 	piqic_ocaml.ml \
 
 
-PACKS = piqilib bytes
+PACKS = core core_kernel piqilib bytes
+export THREADS=yes
 INCDIRS = ../piqirun
 LIBS = ../piqirun/piqirun
 

--- a/piqic-ocaml/piqic_ocaml.ml
+++ b/piqic-ocaml/piqic_ocaml.ml
@@ -179,6 +179,7 @@ let piqic context =
 (* this is the same as calling "piqi compile ..." and reading its output but,
  * instead, we are just using the library functions *)
 let piqi_compile_piqi ifile =
+  let open Core.Std.String in
   let self_spec_bin = T.piqi in
   (* by adding "ocaml" extension, we tell the library to automatically load
    * *.ocaml.piqi extension modules *)

--- a/piqic-ocaml/piqic_ocaml_ext.ml
+++ b/piqic-ocaml/piqic_ocaml_ext.ml
@@ -112,7 +112,7 @@ let gen_import context import =
 
 
 let gen_imports context l =
-  let l = List.map (gen_import context) l in
+  let l = Core.Std.List.map ~f:(gen_import context) l in
   iol l
 
 
@@ -126,10 +126,10 @@ let gen_piqi context =
    * for built-in types to work *)
   let typedefs = List.filter (fun x -> not (C.is_builtin_typedef x)) typedefs in
 
-  let type_initializers = List.map (gen_init_piqi_type context) typedefs in
-  let parsers = List.map (gen_parse modname) typedefs in
-  let generators = List.map (gen_gen modname) typedefs in
-  let printers = List.map gen_print typedefs in
+  let type_initializers = Core.Std.List.map ~f:(gen_init_piqi_type context) typedefs in
+  let parsers = Core.Std.List.map ~f:(gen_parse modname) typedefs in
+  let generators = Core.Std.List.map ~f:(gen_gen modname) typedefs in
+  let printers = Core.Std.List.map ~f:gen_print typedefs in
 
   iol [
     gen_imports context piqi.P.import;

--- a/piqic-ocaml/piqic_ocaml_in.ml
+++ b/piqic-ocaml/piqic_ocaml_in.ml
@@ -140,7 +140,7 @@ let gen_record context r =
   let fields = List.sort (fun a b -> compare a.F.code b.F.code) r.R.field in
   let fconsl = (* field constructor list *)
     if fields <> []
-    then List.map (gen_field_cons context rname) fields
+    then Core.Std.List.map ~f:(gen_field_cons context rname) fields
     else [ios rname; ios "._dummy = ();"]
   in
   let fconsl =
@@ -149,7 +149,7 @@ let gen_record context r =
     else fconsl
   in
   let fparserl = (* field parsers list *)
-    List.map (gen_field_parser context) fields
+    Core.Std.List.map ~f:(gen_field_parser context) fields
   in
   let rcons = (* record constructor *)
     iol [
@@ -179,7 +179,7 @@ let gen_const c =
 
 let gen_enum e ~is_packed =
   let open Enum in
-  let consts = List.map gen_const e.option in
+  let consts = Core.Std.List.map ~f:gen_const e.option in
   let packed_prefix = C.gen_packed_prefix is_packed in
   iol [
     packed_prefix; ios "parse_"; ios (some_of e.ocaml_name); ios " x =";
@@ -246,7 +246,7 @@ let gen_variant context v =
   let open Variant in
   let name = some_of v.ocaml_name in
   let scoped_name = C.scoped_name context name in
-  let options = List.map (gen_option context scoped_name) v.option in
+  let options = Core.Std.List.map ~f:(gen_option context scoped_name) v.option in
   iol [
     ios "parse_"; ios name; ios " x =";
     ioi [
@@ -329,7 +329,7 @@ let gen_typedefs context typedefs =
   if typedefs = []
   then iol []
   else
-    let defs = List.map (gen_typedef context) typedefs in
+    let defs = Core.Std.List.map ~f:(gen_typedef context) typedefs in
     iol [
       gen_cc "let next_count = Piqloc.next_icount\n";
       gen_cc "let curr_count () = !Piqloc.icount\n";

--- a/piqic-ocaml/piqic_ocaml_out.ml
+++ b/piqic-ocaml/piqic_ocaml_out.ml
@@ -112,7 +112,7 @@ let gen_record context r =
   (* order fields by are by their integer codes *)
   let fields = List.sort (fun a b -> compare a.F.code b.F.code) r.R.field in
   let fgens = (* field generators list *)
-    List.map (gen_field context rname) fields
+    Core.Std.List.map ~f:(gen_field context rname) fields
   in
   (* field names *)
   let fnames, _ = List.split fgens in
@@ -120,8 +120,8 @@ let gen_record context r =
   let esc x = ios "_" ^^ ios x in
 
   (* field generator code *)
-  let fgens_code = List.map
-    (fun (name, gen) -> iol [ios "let "; esc name; ios " = "; gen; ios " in"; eol])
+  let fgens_code = Core.Std.List.map
+    ~f:(fun (name, gen) -> iol [ios "let "; esc name; ios " = "; gen; ios " in"; eol])
     fgens
   in
   let unknown_fields =
@@ -135,7 +135,7 @@ let gen_record context r =
       gen_cc "refer x;\n";
       iol fgens_code;
       ios "Piqirun.gen_record code (";
-        iod " :: " ((List.map esc fnames) @ unknown_fields);
+        iod " :: " ((Core.Std.List.map ~f:esc fnames) @ unknown_fields);
       ios ")";
     ]
   ]
@@ -150,7 +150,7 @@ let gen_const c =
 
 
 let gen_enum_consts l =
-  let consts = List.map gen_const l in
+  let consts = Core.Std.List.map ~f:gen_const l in
   iol [
     ios "(match x with";
     ioi (newlines consts);
@@ -222,7 +222,7 @@ let gen_option context o =
 
 let gen_variant context v =
   let open Variant in
-  let options = List.map (gen_option context) v.option in
+  let options = Core.Std.List.map ~f:(gen_option context) v.option in
   let typename = Piqic_ocaml_types.gen_typedef_type context (`variant v) in
   iol [
     ios "gen__"; ios (some_of v.ocaml_name); ios " code (x:"; ios typename; ios ") =";
@@ -306,8 +306,8 @@ let gen_typedefs context typedefs =
   if typedefs = []
   then iol []
   else
-    let defs_2 = List.map (gen_typedef_2 context) typedefs in
-    let defs_1 = List.map gen_typedef_1 typedefs in
+    let defs_2 = Core.Std.List.map ~f:(gen_typedef_2 context) typedefs in
+    let defs_1 = Core.Std.List.map ~f:gen_typedef_1 typedefs in
     iol [
       gen_cc "let next_count = Piqloc.next_ocount\n";
       (* NOTE: providing special handling for boxed objects, since they are not

--- a/piqic-ocaml/piqic_ocaml_types.ml
+++ b/piqic-ocaml/piqic_ocaml_types.ml
@@ -111,7 +111,7 @@ let gen_record_mod context r =
   let fields = r.R.field in
   let fdefs = (* field definition list *)
     if fields <> []
-    then List.map (gen_field context) fields
+    then Core.Std.List.map ~f:(gen_field context) fields
     else [ios "_dummy: unit;"]
   in
   let fdefs =
@@ -192,7 +192,7 @@ let gen_list context l =
 
 
 let gen_options context options =
-  let options_code = List.map (gen_option context) options in
+  let options_code = Core.Std.List.map ~f:(gen_option context) options in
   ioi [
     ios "[";
     ioi (prefix "| " options_code |> newlines);
@@ -285,7 +285,7 @@ let gen_import context import =
 
 
 let gen_imports context l =
-  let l = List.map (gen_import context) l in
+  let l = Core.Std.List.map ~f:(gen_import context) l in
   iol l
 
 

--- a/piqirun/Makefile
+++ b/piqirun/Makefile
@@ -5,7 +5,9 @@ RESULT = piqirun
 
 
 # piqirun_ext.ml depends on it
-PACKS = piqilib bytes
+PACKS = core core_kernel piqilib bytes 
+export THREADS=yes
+export ANNOTATE=yes
 
 
 SOURCES = \

--- a/piqirun/piqirun.ml
+++ b/piqirun/piqirun.ml
@@ -771,7 +771,7 @@ let parse_optional_field code parse_value ?default l =
 
 let parse_repeated_field code parse_value l =
   let res, rem = find_fields code l in
-  List.map parse_value res, rem
+  Core.Std.List.map ~f:parse_value res, rem
 
 
 (* similar to List.map but store results in a newly created output array *)
@@ -891,7 +891,7 @@ let parse_list_elem parse_value (code, x) =
 
 let parse_list parse_value obj =
   let l = parse_record obj in
-  List.map (parse_list_elem parse_value) l
+  Core.Std.List.map ~f:(parse_list_elem parse_value) l
 
 
 let parse_array parse_value obj =
@@ -1312,7 +1312,7 @@ let gen_parsed_field (code, value) =
 
 
 let gen_parsed_field_list l =
-  List.map gen_parsed_field l
+  Core.Std.List.map ~f:gen_parsed_field l
 
 
 (*
@@ -1390,7 +1390,7 @@ let gen_optional_field code f = function
 
 
 let gen_repeated_field code f l =
-  iol (List.map (f code) l)
+  iol (Core.Std.List.map ~f:(f code) l)
 
 
 (* similar to Array.map but produces list instead of array *)
@@ -1422,7 +1422,7 @@ let gen_packed_repeated_field_common code contents =
 
 
 let gen_packed_repeated_field code f l =
-  let contents = iol_size (List.map f l) in
+  let contents = iol_size (Core.Std.List.map ~f l) in
   gen_packed_repeated_field_common code contents
 
 
@@ -1466,7 +1466,7 @@ let gen_record code contents =
 (* generate binary representation of <type>_list .proto structure *)
 let gen_list f code l =
   (* NOTE: using "1" as list element code *)
-  let contents = List.map (f 1) l in
+  let contents = Core.Std.List.map ~f:(f 1) l in
   gen_record code contents
 
 

--- a/piqirun/piqirun_ext.ml
+++ b/piqirun/piqirun_ext.ml
@@ -20,7 +20,6 @@
  * "piqic-ocaml --multi-format" Piqi compiler
  *)
 
-
 type input_format = [ `piq | `json | `xml | `pb | `pib ]
 
 type output_format = [ input_format | `json_pretty | `xml_pretty ]

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,6 +1,7 @@
 include ../make/Makefile.dirs
 
 
+PACKS+=core core_kernel
 DIRS = \
        piqirun \
        addressbook \

--- a/tests/array/Makefile.ocaml
+++ b/tests/array/Makefile.ocaml
@@ -21,7 +21,8 @@ PIQIC = ../../piqic-ocaml/piqic-ocaml
 
 
 export OCAMLPATH := ../..:$(OCAMLPATH)
-PACKS = piqirun.pb
+PACKS = core core_kernel piqirun.pb
+export THREADS=yes
 
 
 all: nc #top

--- a/tests/misc/Makefile
+++ b/tests/misc/Makefile
@@ -31,7 +31,8 @@ PIQIC = ../../piqic-ocaml/piqic-ocaml
 
 
 export OCAMLPATH := ../..:$(OCAMLPATH)
-PACKS = piqirun.pb
+PACKS = core core_kernel piqirun.pb
+export THREADS=yes
 
 
 all: nc #top

--- a/tests/misc1/Makefile
+++ b/tests/misc1/Makefile
@@ -9,7 +9,8 @@ PRE_TARGETS = id.proto.piqi example.proto.piqi id_piqi.ml id_piqi_ext.ml example
 
 
 export OCAMLPATH := ../..:$(OCAMLPATH)
-PACKS = piqirun.ext
+PACKS = core core_kernel piqirun.ext
+export THREADS=yes
 
 
 PIQI ?= piqi

--- a/tests/packed/Makefile.ocaml
+++ b/tests/packed/Makefile.ocaml
@@ -23,7 +23,8 @@ PIQIC = ../../piqic-ocaml/piqic-ocaml
 
 
 export OCAMLPATH := ../..:$(OCAMLPATH)
-PACKS = piqirun.pb
+PACKS = core core_kernel piqirun.pb
+export THREADS=yes
 
 
 all: nc #top

--- a/tests/perf/Makefile
+++ b/tests/perf/Makefile
@@ -1,6 +1,8 @@
 .PHONY: all ocaml test clean
 
 
+PACKS=core core_kernel
+export THREADS=yes
 PIQI ?= piqi
 
 

--- a/tests/perf/Makefile.ocaml
+++ b/tests/perf/Makefile.ocaml
@@ -10,7 +10,8 @@ SOURCES = \
 
 
 export OCAMLPATH := ../..:$(OCAMLPATH)
-PACKS = unix piqirun.ext
+PACKS = core core_kernel unix piqirun.ext
+export THREADS=yes
 
 
 PIQI_FILES = addressbook.proto.piqi piqi.piqi piqi-obj.piqi

--- a/tests/piqi/Makefile.ocaml
+++ b/tests/piqi/Makefile.ocaml
@@ -16,7 +16,9 @@ PIQIC = ../../piqic-ocaml/piqic-ocaml
 
 
 export OCAMLPATH := ../..:$(OCAMLPATH)
-PACKS = piqirun.pb
+PACKS = core core_kernel piqirun.pb
+export THREADS=yes
+
 
 
 all: bc #top

--- a/tests/piqirun/Makefile
+++ b/tests/piqirun/Makefile
@@ -7,7 +7,8 @@ SOURCES = test.ml
 
 
 export OCAMLPATH := ../..:$(OCAMLPATH)
-PACKS = piqirun.pb
+PACKS = core core_kernel piqirun.pb
+export THREADS=yes
 
 
 all: bc

--- a/tests/riak_pb/Makefile
+++ b/tests/riak_pb/Makefile
@@ -16,7 +16,8 @@ PIQI_ML_FILES = $(PROTO_FILES:%.proto=%_piqi.ml)
 
 
 export OCAMLPATH := ../..:$(OCAMLPATH)
-PACKS = piqirun.pb
+PACKS = core core_kernel piqirun.pb
+export THREADS=yes
 
 
 PIQI ?= piqi


### PR DESCRIPTION
So, I didn't have time to make sure and remove Core in favor of Core_kernel-that's the only drawback. But I was relentless in chasing down this bug. Holy crap did this take a long time. I'm pretty sure that there is literally no instance of pervasives' List.map. I think I'll have to make a later pass for memory leaking, but for now, it's not blowing up due to stack exhaustion.