### PR TITLE
Pervasives -> Stdlib

### DIFF
--- a/opam
+++ b/opam
@@ -20,6 +20,7 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "ocamlfind" {build}
   "piqilib"
+  "stdlib-shims"
   "num" {with-test}
 ]
 dev-repo: "git://github.com/alavrik/piqi-ocaml"

--- a/piqic-ocaml/Makefile
+++ b/piqic-ocaml/Makefile
@@ -18,7 +18,7 @@ SOURCES = \
 	piqic_ocaml.ml \
 
 
-PACKS = piqilib bytes
+PACKS = piqilib bytes stdlib-shims
 INCDIRS = ../piqirun
 LIBS = ../piqirun/piqirun
 

--- a/piqic-ocaml/piqic_ocaml_ext.ml
+++ b/piqic-ocaml/piqic_ocaml_ext.ml
@@ -88,10 +88,10 @@ let gen_print typedef =
   let name = C.typedef_mlname typedef in
   iol [
     ios "let print_"; ios name; ios " ?opts x ="; eol;
-    ios "  Pervasives.print_endline (gen_"; ios name; ios " x `piq ?opts)";
+    ios "  Stdlib.print_endline (gen_"; ios name; ios " x `piq ?opts)";
     eol;
     ios "let prerr_"; ios name; ios " ?opts x ="; eol;
-    ios "  Pervasives.prerr_endline (gen_"; ios name; ios " x `piq ?opts)";
+    ios "  Stdlib.prerr_endline (gen_"; ios name; ios " x `piq ?opts)";
     eol;
   ]
 

--- a/piqirun/Makefile
+++ b/piqirun/Makefile
@@ -5,7 +5,7 @@ RESULT = piqirun
 
 
 # piqirun_ext.ml depends on it
-PACKS = piqilib
+PACKS = piqilib stdlib-shims
 
 
 SOURCES = \

--- a/piqirun/piqirun.ml
+++ b/piqirun/piqirun.ml
@@ -203,7 +203,7 @@ module IBuf =
         | Channel x ->
             let start_pos = pos_in x in
             let s = Bytes.create length in
-            (try Pervasives.really_input x s 0 length
+            (try Stdlib.really_input x s 0 length
              with End_of_file -> raise End_of_buffer
             );
             of_string (Bytes.unsafe_to_string s) start_pos


### PR DESCRIPTION
Pervasives is deprecated. Anyone who wants to keep compatibility with OCaml < 4.07 just need to add a dependency to `stdlib-shims`.