### PR TITLE
Use let () instead of let _ for ignored value

### DIFF
--- a/piqic-ocaml/piqic_ocaml_ext.ml
+++ b/piqic-ocaml/piqic_ocaml_ext.ml
@@ -29,7 +29,7 @@ let gen_init_piqi modname =
   iol [
     ios "let piqi = "; ios modname; ios ".piqi"; eol;
     eol; eol;
-    ios "let _ = Piqirun_ext.init_piqi piqi"; eol;
+    ios "let () = Piqirun_ext.init_piqi piqi"; eol;
   ]
 
 


### PR DESCRIPTION
This is simply to ease use of piqi with code that may (transitively) bring in
ppx_js_style, which requires explicit type annotation of ignored values:

https://github.com/janestreet/ppx_js_style#-allow-unannotated-ignores