### PR TITLE
switches to dune

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 
 # vim:
 *.swp
+/_build/

--- a/dune
+++ b/dune
@@ -1,0 +1,1 @@
+(env (dev (flags (:standard -warn-error -A))))

--- a/dune-project
+++ b/dune-project
@@ -1,0 +1,3 @@
+(lang dune 2.0)
+
+(package (name piqirun))

--- a/opam
+++ b/opam
@@ -4,18 +4,6 @@ authors: "Anton Lavrik <alavrik@piqi.org>"
 maintainer: "Anton Lavrik <alavrik@piqi.org>"
 homepage: "https://github.com/alavrik/piqi-ocaml"
 bug-reports: "https://github.com/alavrik/piqi-ocaml/issues"
-build: [
-  [make]
-  [make "test"] {with-test}
-]
-install: [
-  [make "DESTDIR=%{prefix}%" "install"]
-]
-remove: [
-  ["rm" "-f" "%{prefix}%/bin/piqic-ocaml"]
-  ["ocamlfind" "remove" "piqirun"]
-]
-flags: light-uninstall
 depends: [
   "ocaml" {>= "4.02.0"}
   "ocamlfind" {build}
@@ -24,3 +12,18 @@ depends: [
   "num" {with-test}
 ]
 dev-repo: "git://github.com/alavrik/piqi-ocaml"
+
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+  name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+  "@doc" {with-doc}
+  ]
+]

--- a/piqic-ocaml/dune
+++ b/piqic-ocaml/dune
@@ -1,0 +1,9 @@
+(executable
+ (name piqic_ocaml)
+ (public_name piqic-ocaml)
+ (libraries piqilib piqirun bytes stdlib-shims))
+
+(rule
+ (target piqic_ocaml_version.ml)
+ (action (with-stdout-to %{target}
+          (bash ./make_version.sh))))

--- a/piqic-ocaml/make_version.sh
+++ b/piqic-ocaml/make_version.sh
@@ -1,0 +1,1 @@
+echo "let version = \"$(head -1 ../VERSION)\""

--- a/piqirun/dune
+++ b/piqirun/dune
@@ -1,0 +1,13 @@
+(library
+  (name piqirun)
+  (public_name piqirun.pb)
+  (wrapped false)
+  (libraries piqilib stdlib-shims)
+  (modules piqirun))
+
+(library
+  (name piqirun_ext)
+  (public_name piqirun.ext)
+  (wrapped false)
+  (libraries piqilib stdlib-shims)
+  (modules piqirun_ext))


### PR DESCRIPTION
The only breaking change is that we have `piqirun.pb` and `piqirun.ext` but not `piqirun`, dune doesn't allow this. It should be noted that, in fact, piqirun was an empty library, which shouldn't be referenced at all and probably was added accidentally. See alavrik/piqi#68