### PR TITLE
uses explicit install field to install packages

### DIFF
--- a/opam
+++ b/opam
@@ -22,6 +22,7 @@ build: [
     "piqi,piqirun"
     "-j"
     jobs
+    "@install"
     "@runtest" {with-test}
     "@doc" {with-doc}
   ]

--- a/opam
+++ b/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/alavrik/piqi-ocaml"
 bug-reports: "https://github.com/alavrik/piqi-ocaml/issues"
 depends: [
   "ocaml" {>= "4.02.0"}
-  "ocamlfind" {build}
+  "dune" {>= "2.0.0"}
   "piqilib"
   "stdlib-shims"
   "num" {with-test}
@@ -22,8 +22,11 @@ build: [
     "piqi,piqirun"
     "-j"
     jobs
-    "@install"
     "@runtest" {with-test}
-  "@doc" {with-doc}
+    "@doc" {with-doc}
   ]
+]
+
+install: [
+  ["dune" "install"]
 ]


### PR DESCRIPTION
With  `dune -p piqi,piqirun @install` dune generates two proper install packages `piqi.install` and `piqirun.install`. However, opam will only use the `piqi.install` file and ignore the latter, so the `piqirun` library is not installed.

