### PR TITLE
adds packages to the dune install invocaton

### DIFF
--- a/opam
+++ b/opam
@@ -29,5 +29,5 @@ build: [
 ]
 
 install: [
-  ["dune" "install"]
+  ["dune" "install" "-p" "piqi,piqirun"]
 ]


### PR DESCRIPTION
Not sure why we can't reproduce it locally, I even installed exactly the same tools versions. But it looks like that this is related to https://github.com/ocaml/dune/pull/5969 and https://github.com/ocaml/dune/issues/4814

I will update accordingly the opam-repository's opam file. In my fork the tests [are passing][1] and I hope that they will still pass when we will push it. 

[1]: https://github.com/ivg/piqi-ocaml/pull/1